### PR TITLE
added smtp-url-analysis-no-db.git

### DIFF
--- a/initconf/bro-pkg.index
+++ b/initconf/bro-pkg.index
@@ -1,3 +1,4 @@
 https://github.com/initconf/scan-NG
 https://github.com/initconf/CVE-2017-5638_struts.git
 https://github.com/initconf/phish-analysis.git
+https://github.com/initconf/smtp-url-analysis-no-db.git


### PR DESCRIPTION
This is a lighter version of smtp-url-analysis work without dependency on postgres. 

