### PR TITLE
Simple policy to detect VNC (RFB) scanners based on src->dst 

### DIFF
--- a/initconf/bro-pkg.index
+++ b/initconf/bro-pkg.index
@@ -3,3 +3,4 @@ https://github.com/initconf/CVE-2017-5638_struts
 https://github.com/initconf/phish-analysis
 https://github.com/initconf/smtp-url-analysis
 https://github.com/initconf/blacklist
+https://github.com/initconf/vnc-scanner


### PR DESCRIPTION
connection counts