### PR TITLE
Add bro-napatech package

### DIFF
--- a/hosom/bro-pkg.index
+++ b/hosom/bro-pkg.index
@@ -1,2 +1,3 @@
 https://github.com/hosom/file-extraction
 https://github.com/hosom/log-filters
+https://github.com/hosom/bro-napatech


### PR DESCRIPTION
bro-napatech is a packet source plugin that can be used in combination with Napatech FPGA NICs.