### PR TITLE
Added bro-pf_ring package

### DIFF
--- a/ntop/bro-pkg.index
+++ b/ntop/bro-pkg.index
@@ -1,0 +1,1 @@
+https://github.com/ntop/bro-pf_ring


### PR DESCRIPTION
This is currently missing leaving the install instructions to fail, as detailed here: https://github.com/ntop/bro-pf_ring