### PR TITLE
Add af_xdp plugin

### DIFF
--- a/irtimmer/bro-pkg.index
+++ b/irtimmer/bro-pkg.index
@@ -1,0 +1,1 @@
+https://github.com/irtimmer/bro-xdp_packet-plugin


### PR DESCRIPTION
This adds my WIP plugin to support AF_XDP from Linux 4.18+